### PR TITLE
Set bUseLobbiesIfAvailable to true

### DIFF
--- a/Source/BYGMultiplayer/Public/BYGMultiplayerSubsystem.h
+++ b/Source/BYGMultiplayer/Public/BYGMultiplayerSubsystem.h
@@ -60,6 +60,7 @@ public:
 		BaseSettings.bUsesPresence = bUsesPresence;
 		BaseSettings.bAllowJoinInProgress = bAllowJoinInProgress;
 		BaseSettings.bAllowJoinViaPresence = bAllowJoinViaPresence;
+		BaseSettings.bUseLobbiesIfAvailable = true;
 		BaseSettings.Set<FString>(SETTING_MAPNAME, TargetPublicFacingMapName, EOnlineDataAdvertisementType::ViaOnlineServiceAndPing);
 		// Custom but we can standardize it
 		BaseSettings.Set<FString>(SETTING_SERVER_NAME, ServerName, EOnlineDataAdvertisementType::ViaOnlineServiceAndPing);


### PR DESCRIPTION
It seems that the Steam plugin at least _requires_ this to be set to true in order to work correctly.